### PR TITLE
修复 bug：当dubbo接口注册为服务别称时，consumer端找不到可用 provider

### DIFF
--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistry.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistry.java
@@ -231,12 +231,13 @@ public class PolarisRegistry extends FailbackRegistry {
     }
 
     private void onInstances(URL url, NotifyListener listener, Instance[] instances) {
+        String requireInterface = url.getServiceInterface();
         LOGGER.info("[POLARIS] update instances count: {}, service: {}", null == instances ? 0 : instances.length,
-                url.getServiceInterface());
+                requireInterface);
         List<URL> urls = new ArrayList<>();
         if (null != instances) {
             for (Instance instance : instances) {
-                urls.add(instanceToURL(instance));
+                urls.add(instanceToURL(requireInterface, instance));
             }
         }
         URL routerURL = buildRouterURL(url);
@@ -246,9 +247,10 @@ public class PolarisRegistry extends FailbackRegistry {
         PolarisRegistry.this.notify(url, listener, urls);
     }
 
-    private static URL instanceToURL(Instance instance) {
+    private static URL instanceToURL(String requireInterface, Instance instance) {
         Map<String, String> newMetadata = new HashMap<>(instance.getMetadata());
         boolean hasWeight = false;
+        newMetadata.put("interface", requireInterface);
         if (newMetadata.containsKey(Constants.WEIGHT_KEY)) {
             String weightStr = newMetadata.get(Constants.WEIGHT_KEY);
             try {

--- a/dubbox/dubbox-examples/dubbox-router-example/dubbox-router-example-api/src/main/java/com/tencent/polaris/dubbox/router/example/api/FooRequest.java
+++ b/dubbox/dubbox-examples/dubbox-router-example/dubbox-router-example-api/src/main/java/com/tencent/polaris/dubbox/router/example/api/FooRequest.java
@@ -17,7 +17,9 @@
 
 package com.tencent.polaris.dubbox.router.example.api;
 
-public class FooRequest {
+import java.io.Serializable;
+
+public class FooRequest implements Serializable {
 
     private String user;
 

--- a/dubbox/dubbox-examples/dubbox-router-example/dubbox-router-example-api/src/main/java/com/tencent/polaris/dubbox/router/example/api/FooResponse.java
+++ b/dubbox/dubbox-examples/dubbox-router-example/dubbox-router-example-api/src/main/java/com/tencent/polaris/dubbox/router/example/api/FooResponse.java
@@ -17,7 +17,9 @@
 
 package com.tencent.polaris.dubbox.router.example.api;
 
-public class FooResponse {
+import java.io.Serializable;
+
+public class FooResponse implements Serializable {
 
     private String message;
 

--- a/dubbox/dubbox-examples/dubbox-router-example/pom.xml
+++ b/dubbox/dubbox-examples/dubbox-router-example/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>com.tencent.polaris</groupId>
-            <artifactId>dubbo-router-polaris</artifactId>
+            <artifactId>dubbox-router-polaris</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
**背景：**  ZooKeeper内注册的dubbo服务同步到Polaris时，把url中的{application}注册为服务，url中的{interface}注册为服务别称。
**问题：**  当consumer端调用服务时，是把{interface}作为服务从Polaris获取实例；而Polars返回实例的interface仍然是{application}，引发“No provider available……” 错误。
**解决方案：**  从Polaris得到实例列表时，把实例元数据的 interface 直接设置为被调 interface