### PR TITLE
dubbo向polaris注册服务时，能够把{application}注册为服务、把接口注册为{application}的别称。

### DIFF
--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistry.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistry.java
@@ -87,8 +87,6 @@ public class PolarisRegistry extends FailbackRegistry {
         hasRouter = routerExtensionLoader.hasExtension(ExtensionConsts.PLUGIN_ROUTER_NAME);
         ExtensionLoader<Filter> filterExtensionLoader = ExtensionLoader.getExtensionLoader(Filter.class);
         hasCircuitBreaker = filterExtensionLoader.hasExtension(ExtensionConsts.PLUGIN_CIRCUITBREAKER_NAME);
-
-        RegistryServiceAliasOperator.setup(url);
     }
 
     private URL buildRouterURL(URL consumerUrl) {

--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistry.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistry.java
@@ -40,6 +40,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.tencent.polaris.dubbo.servicealias.RegistryServiceAliasOperator;
+import com.tencent.polaris.dubbo.servicealias.ServiceAlias;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.constants.RegistryConstants;
@@ -84,6 +87,8 @@ public class PolarisRegistry extends FailbackRegistry {
         hasRouter = routerExtensionLoader.hasExtension(ExtensionConsts.PLUGIN_ROUTER_NAME);
         ExtensionLoader<Filter> filterExtensionLoader = ExtensionLoader.getExtensionLoader(Filter.class);
         hasCircuitBreaker = filterExtensionLoader.hasExtension(ExtensionConsts.PLUGIN_CIRCUITBREAKER_NAME);
+
+        RegistryServiceAliasOperator.setup(url);
     }
 
     private URL buildRouterURL(URL consumerUrl) {
@@ -121,8 +126,11 @@ public class PolarisRegistry extends FailbackRegistry {
         if (port > 0) {
             int weight = url.getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
             String version = url.getParameter(CommonConstants.VERSION_KEY, "");
-            polarisOperator.register(url.getServiceInterface(), url.getHost(), port, url.getProtocol(), version, weight,
-                    metadata);
+            polarisOperator.register(RegistryServiceAliasOperator.getService(url), url.getHost(), port,
+                    url.getProtocol(), version, weight, metadata);
+            if (RegistryServiceAliasOperator.enabled()) {
+                RegistryServiceAliasOperator.saveServiceAlias(new ServiceAlias(url));
+            }
             registeredInstances.add(url);
         } else {
             LOGGER.warn("[POLARIS] skip register url {} for zero port value", url);
@@ -141,7 +149,7 @@ public class PolarisRegistry extends FailbackRegistry {
         LOGGER.info("[POLARIS] unregister service from polaris: {}", url.toString());
         int port = url.getPort();
         if (port > 0) {
-            polarisOperator.deregister(url.getServiceInterface(), url.getHost(), url.getPort());
+            polarisOperator.deregister(RegistryServiceAliasOperator.getService(url), url.getHost(), url.getPort());
             registeredInstances.remove(url);
         }
     }

--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistryFactory.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistryFactory.java
@@ -17,6 +17,7 @@
 package com.tencent.polaris.dubbo.registry;
 
 
+import com.tencent.polaris.dubbo.servicealias.RegistryServiceAliasOperator;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.support.AbstractRegistryFactory;

--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistryFactory.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/registry/PolarisRegistryFactory.java
@@ -26,6 +26,7 @@ public class PolarisRegistryFactory extends AbstractRegistryFactory {
 
     @Override
     protected Registry createRegistry(URL url) {
+        url = RegistryServiceAliasOperator.setup(url);
         PolarisRegistry polarisRegistry = new PolarisRegistry(url);
         return polarisRegistry;
     }

--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/servicealias/RegistryServiceAliasOperator.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/servicealias/RegistryServiceAliasOperator.java
@@ -3,9 +3,12 @@ package com.tencent.polaris.dubbo.servicealias;
 import org.apache.dubbo.common.URL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import shade.polaris.okhttp3.*;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.util.concurrent.TimeUnit;
 
@@ -19,21 +22,17 @@ public class RegistryServiceAliasOperator {
     private static final Logger LOGGER = LoggerFactory.getLogger(RegistryServiceAliasOperator.class);
     static String aliasUrl = null;
     static String token = null;
-    static OkHttpClient httpClient = null;
-    static MediaType jsonType = MediaType.get("application/json; charset=utf-8");
 
-    public static void setup(URL registryUrl) {
+    public static URL setup(URL registryUrl) {
         token = registryUrl.getParameter(KEY_Polaris_Rest_Token);
+        if (token == null)
+            return registryUrl;
+
         String port = registryUrl.getParameter(KEY_Polaris_Rest_Port, "8090");
-        if (token != null) {
-            token = URLDecoder.decode(token);
-            aliasUrl = String.format("http://%s:%s/naming/v1/service/alias", registryUrl.getHost(), port);
-            httpClient = new OkHttpClient().newBuilder()
-                    .connectTimeout(3, TimeUnit.SECONDS)
-                    .readTimeout(3, TimeUnit.SECONDS)
-                    .writeTimeout(3, TimeUnit.SECONDS).build();
-            LOGGER.info("[POLARIS] register dubbo service with alias enabled");
-        }
+        token = URLDecoder.decode(token);
+        aliasUrl = String.format("http://%s:%s/naming/v1/service/alias", registryUrl.getHost(), port);
+        LOGGER.info("[POLARIS] register dubbo service with alias enabled");
+        return registryUrl.removeParameter(KEY_Polaris_Rest_Token);
     }
 
     public static boolean enabled() {
@@ -48,14 +47,44 @@ public class RegistryServiceAliasOperator {
         if (!enabled())
             return;
 
-        RequestBody body = RequestBody.create(alias.toJson(), jsonType);
-        Request request = new Request.Builder().url(aliasUrl)
-                .header("X-Polaris-Token", token)
-                .post(body).build();
         try {
-            httpClient.newCall(request).execute();
-        } catch (IOException ex) {
+            post(aliasUrl, token, alias.toJson());
+        } catch (Exception ex) {
             LOGGER.error("[POLARIS] save dubbo service alias %s error", alias.getAlias(), ex);
+        }
+    }
+
+    public static void post(String polarisUrl, String token, String body) throws Exception {
+        PrintWriter out = null;
+        BufferedReader in = null;
+        try {
+            java.net.URL url = new java.net.URL(polarisUrl);
+            URLConnection conn = url.openConnection();
+
+            conn.setRequestProperty("X-Polaris-Token", token);
+            conn.setConnectTimeout(3 * 1000);
+            conn.setRequestProperty("accept", "*/*");
+            conn.setRequestProperty("connection", "Keep-Alive");
+            conn.setRequestProperty("user-agent", "Mozilla/4.0 (compatible;)");
+            conn.setRequestProperty("Content-Type", "application/json"); // 设置内容类型
+
+            conn.setDoOutput(true);
+            conn.setDoInput(true);
+
+            out = new PrintWriter(conn.getOutputStream());
+            out.print(body);
+            out.flush();
+
+            in = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
+            in.readLine();
+        } finally {
+            if (out != null)
+                out.close();
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignore) {}
+            }
         }
     }
 }

--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/servicealias/RegistryServiceAliasOperator.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/servicealias/RegistryServiceAliasOperator.java
@@ -1,0 +1,61 @@
+package com.tencent.polaris.dubbo.servicealias;
+
+import org.apache.dubbo.common.URL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import shade.polaris.okhttp3.*;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ */
+public class RegistryServiceAliasOperator {
+    public static String KEY_Polaris_Rest_Token = "token";
+    public static String KEY_Polaris_Rest_Port = "port";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegistryServiceAliasOperator.class);
+    static String aliasUrl = null;
+    static String token = null;
+    static OkHttpClient httpClient = null;
+    static MediaType jsonType = MediaType.get("application/json; charset=utf-8");
+
+    public static void setup(URL registryUrl) {
+        token = registryUrl.getParameter(KEY_Polaris_Rest_Token);
+        String port = registryUrl.getParameter(KEY_Polaris_Rest_Port, "8090");
+        if (token != null) {
+            token = URLDecoder.decode(token);
+            aliasUrl = String.format("http://%s:%s/naming/v1/service/alias", registryUrl.getHost(), port);
+            httpClient = new OkHttpClient().newBuilder()
+                    .connectTimeout(3, TimeUnit.SECONDS)
+                    .readTimeout(3, TimeUnit.SECONDS)
+                    .writeTimeout(3, TimeUnit.SECONDS).build();
+            LOGGER.info("[POLARIS] register dubbo service with alias enabled");
+        }
+    }
+
+    public static boolean enabled() {
+        return token != null;
+    }
+
+    public static String getService(URL svrUrl) {
+        return enabled() ? ServiceAlias.getApplication(svrUrl) : svrUrl.getServiceInterface();
+    }
+
+    public static void saveServiceAlias(ServiceAlias alias) {
+        if (!enabled())
+            return;
+
+        RequestBody body = RequestBody.create(alias.toJson(), jsonType);
+        Request request = new Request.Builder().url(aliasUrl)
+                .header("X-Polaris-Token", token)
+                .post(body).build();
+        try {
+            httpClient.newCall(request).execute();
+        } catch (IOException ex) {
+            LOGGER.error("[POLARIS] save dubbo service alias %s error", alias.getAlias(), ex);
+        }
+    }
+}

--- a/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/servicealias/ServiceAlias.java
+++ b/dubbo/dubbo-plugins/dubbo-registry-polaris/src/main/java/com/tencent/polaris/dubbo/servicealias/ServiceAlias.java
@@ -1,0 +1,55 @@
+package com.tencent.polaris.dubbo.servicealias;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import org.apache.dubbo.common.URL;
+
+/**
+ * @author <a href="mailto:amyson99@foxmail.com">amyson</a>
+ */
+public class ServiceAlias {
+    private String service;
+    private String namespace;
+    private String alias;
+    @JSONField(name = "alias_namespace")
+    private String aliasNamespace;
+
+    public ServiceAlias(URL url) {
+        this(url, "default");
+    }
+
+    public ServiceAlias(URL url, String namespace) {
+        this(url, namespace, namespace);
+    }
+
+    public ServiceAlias(URL url, String namespace, String aliasNamespace) {
+        this.service = getApplication(url);
+        this.namespace = namespace;
+        this.alias = url.getServiceInterface();
+        this.aliasNamespace = aliasNamespace;
+    }
+
+    public static String getApplication(URL url) {
+        return url.getParameter("application");
+    }
+
+    public String toJson() {
+        return JSON.toJSONString(this);
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getAliasNamespace() {
+        return aliasNamespace;
+    }
+}

--- a/dubbo/dubbo-plugins/dubbo-router-polaris/pom.xml
+++ b/dubbo/dubbo-plugins/dubbo-router-polaris/pom.xml
@@ -15,6 +15,11 @@
     <dependencies>
         <dependency>
             <groupId>com.tencent.polaris</groupId>
+            <artifactId>polaris-all</artifactId>
+            <version>${polaris.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.polaris</groupId>
             <artifactId>dubbo-registry-polaris</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/dubbo/dubbo-plugins/dubbo-router-polaris/src/main/java/com/tencent/polaris/dubbo/router/PolarisRouter.java
+++ b/dubbo/dubbo-plugins/dubbo-router-polaris/src/main/java/com/tencent/polaris/dubbo/router/PolarisRouter.java
@@ -59,7 +59,7 @@ public class PolarisRouter extends AbstractRouter {
                 url.getParameters());
         this.priority = url.getParameter(Constants.PRIORITY_KEY, 0);
         routeRuleHandler = new RuleHandler();
-        polarisOperator = PolarisOperators.INSTANCE.getPolarisOperator(url.getHost(), url.getPort());
+        polarisOperator = PolarisOperators.INSTANCE.getFirstPolarisOperator(); //这里url是provider，根据地址信息是获取不到的
         parser = QueryParser.load();
     }
 

--- a/polaris-adapter-dubbo/pom.xml
+++ b/polaris-adapter-dubbo/pom.xml
@@ -16,6 +16,13 @@
         <dependency>
             <groupId>com.tencent.polaris</groupId>
             <artifactId>polaris-all</artifactId>
+            <version>${polaris.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.21.7</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/polaris-adapter-dubbo/src/main/java/com/tencent/polaris/common/parser/QueryParser.java
+++ b/polaris-adapter-dubbo/src/main/java/com/tencent/polaris/common/parser/QueryParser.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.common.parser;
 
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -28,13 +29,13 @@ public interface QueryParser {
     String name();
 
     static QueryParser load() {
-        ServiceLoader<QueryParser> loader = ServiceLoader.load(QueryParser.class);
-        QueryParser instance = loader.iterator().next();
+        Iterator<QueryParser> queryParserIter = ServiceLoader.load(QueryParser.class).iterator();
+        QueryParser instance = queryParserIter.hasNext() ? queryParserIter.next() : null;
         if (Objects.nonNull(instance)) {
             return instance;
         }
         String parser = System.getProperty("dubbo.polaris.query_parser");
-        if (parser.equals("JsonPath")) {
+        if ("JsonPath".equals(parser)) {
             return new JsonPathQueryParser();
         }
         return new JavaObjectQueryParser();

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <!-- Project revision -->
-        <revision>0.2.2</revision>
+        <revision>0.3.0-20230901</revision>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -52,7 +52,7 @@
         <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
         <maven.deploy.plugin.version>3.0.0-M1</maven.deploy.plugin.version>
         <maven.flatten.plugin.version>1.2.5</maven.flatten.plugin.version>
-        <polaris.version>1.12.10</polaris.version>
+        <polaris.version>1.13.0</polaris.version>
         <slf4j.version>1.7.25</slf4j.version>
         <json_path_version>2.8.0</json_path_version>
     </properties>


### PR DESCRIPTION
- 配置polaris注册中心地址时，只需提供token参数就可以启用该功能
- 不提供token参数，完全兼容原来的逻辑
- 使用别称后，后续的灰度发布等涉及标签设置的操作只需在服务下的实例上操作一次，便于管理