### PR TITLE
fix:fix incorrect empty metadata data handling.

### DIFF
--- a/dubbo-plugins/dubbo-metadatareport-polaris/src/main/java/com/tencent/polaris/dubbo/metadata/report/PolarisMetadataReport.java
+++ b/dubbo-plugins/dubbo-metadatareport-polaris/src/main/java/com/tencent/polaris/dubbo/metadata/report/PolarisMetadataReport.java
@@ -25,6 +25,8 @@ import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
 import com.tencent.polaris.api.pojo.ServiceRule;
 import com.tencent.polaris.api.rpc.GetServiceContractRequest;
 import com.tencent.polaris.api.rpc.ServiceRuleResponse;
+import com.tencent.polaris.api.utils.CollectionUtils;
+import com.tencent.polaris.api.utils.StringUtils;
 import com.tencent.polaris.common.context.Context;
 import com.tencent.polaris.common.registry.PolarisConfig;
 import com.tencent.polaris.common.registry.PolarisOperator;
@@ -33,9 +35,9 @@ import com.tencent.polaris.common.utils.Consts;
 import com.tencent.polaris.specification.api.v1.service.manage.ServiceContractProto;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.config.configcenter.ConfigItem;
-import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
-import org.apache.dubbo.common.logger.LoggerFactory;
-import org.apache.dubbo.common.utils.*;
+import org.apache.dubbo.common.utils.ConcurrentHashSet;
+import org.apache.dubbo.common.utils.JsonUtils;
+import org.apache.dubbo.common.utils.NamedThreadFactory;
 import org.apache.dubbo.metadata.MappingChangedEvent;
 import org.apache.dubbo.metadata.MappingListener;
 import org.apache.dubbo.metadata.MetadataInfo;
@@ -54,8 +56,6 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.dubbo.metadata.MetadataConstants.REPORT_CONSUMER_URL_KEY;
 
 public class PolarisMetadataReport extends AbstractMetadataReport {
-
-    protected final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(getClass());
 
     private final PolarisOperator operator;
 
@@ -160,6 +160,12 @@ public class PolarisMetadataReport extends AbstractMetadataReport {
         for (ServiceContractProto.InterfaceDescriptor descriptor : result.get().getInterfacesList()) {
             MetadataInfo.ServiceInfo serviceInfo = JsonUtils.toJavaObject(descriptor.getContent(), MetadataInfo.ServiceInfo.class);
             serviceInfos.put(serviceInfo.getMatchKey(), serviceInfo);
+        }
+        if (CollectionUtils.isEmpty(serviceInfos)) {
+            String warnMsg = String.format("Get app metadata empty, service name is %s, revision is %s, param is %s",
+                    identifier.getApplication(), identifier.getRevision(), instanceMetadata);
+            logger.warn(warnMsg);
+            return MetadataInfo.EMPTY;
         }
         return new MetadataInfo(identifier.getApplication(), identifier.getRevision(), serviceInfos);
     }


### PR DESCRIPTION
fix #75 

# 实例更新流程

核心逻辑源码：org.apache.dubbo.registry.client.event.listener.ServiceInstancesChangedListener#doOnEvent

1. 当dubbo订阅（subscribe）URL的时候，会绑定实例变更监听器（`ServiceInstancesChangedListener`）。
<img width="700" alt="Clipboard_Screenshot_1744081783" src="https://github.com/user-attachments/assets/07d45b93-2d30-4b13-b907-cd875feccc11" />

2. 在polaris-dubbo-java中，将绑定polaris-java定义的变更监听器（`InnerServiceListener`）与之对应。
<img width="700" alt="Clipboard_Screenshot_1744081819" src="https://github.com/user-attachments/assets/84e40674-ff50-4572-9b24-8f0c7df34a91" />

3. 实例更新时，会触发实例变更监听器的doOnEvent方法。
<img width="700" alt="Clipboard_Screenshot_1744082765" src="https://github.com/user-attachments/assets/c21f2ca7-2493-4fb3-b349-aace2d92aa94" />

4. 实例变更监听器从新的实例列表，解析出revision映射到实例列表的map。
<img width="700" alt="Clipboard_Screenshot_1744083392" src="https://github.com/user-attachments/assets/0fd347de-49d8-417b-9039-2f1395481daa" />

5. 针对每个revision，先从实例中获取service metadata，如果没有，再去远端拉取service metadata。
<img width="700" alt="Clipboard_Screenshot_1744083423" src="https://github.com/user-attachments/assets/3ce9794a-a3aa-4167-af21-c5dae734e62f" />

6. 将获取的service metadata塞回实例内。
<img width="700" alt="Clipboard_Screenshot_1744083578" src="https://github.com/user-attachments/assets/fbb5d1e1-b391-4ff9-9804-cdaa00afe0ad" />

7. 最后构造url，并刷新
<img width="351" alt="Clipboard_Screenshot_1744083664" src="https://github.com/user-attachments/assets/2f61a6b0-6857-41a4-b680-2b0c48bb9c00" />

# 原有逻辑

在上述流程的第5步，获取到service metadata拉取到空值，也会正常更新。例如下方serviceInfos为空map，也正常返回了。
<img width="700" alt="Clipboard_Screenshot_1744084454" src="https://github.com/user-attachments/assets/7dd05783-0884-4320-8d09-152566a8c74f" />

# 解决方案

1. 可以借助dubbo的metadata异常处理流程来完成service metadata的拉取。也就是serviceInfos为空map时，返回dubbo框架内指定的空值，`MetadataInfo.EMPTY`。

2. dubbo框架在获取远端service metadata时，如果拿到了`MetadataInfo.EMPTY`，则会重试2次，且每次重试间隔1000ms。源码：org.apache.dubbo.registry.client.AbstractServiceDiscovery#getRemoteMetadata(java.lang.String, java.util.List<org.apache.dubbo.registry.client.ServiceInstance>)

3. 如果重试后还是为`MetadataInfo.EMPTY`，则会走到实例变更监听器重试逻辑。这个重试逻辑会判断是否有实例存在空的service metadata，则会提交一个重试任务，等待10000ms后，重新触发整个url列表的变更。
<img width="700" alt="Clipboard_Screenshot_1744094778" src="https://github.com/user-attachments/assets/7f97ef96-5fa2-431c-8200-2f537e646280" />

4. 经过两层重试后，便可正确获取service metadata，即使是北极星AP架构。