### PR TITLE
fix:fix NPE when using getConfigItem.

### DIFF
--- a/dubbo-plugins/dubbo-metadatareport-polaris/src/main/java/com/tencent/polaris/dubbo/metadata/report/PolarisMetadataReport.java
+++ b/dubbo-plugins/dubbo-metadatareport-polaris/src/main/java/com/tencent/polaris/dubbo/metadata/report/PolarisMetadataReport.java
@@ -153,7 +153,7 @@ public class PolarisMetadataReport extends AbstractMetadataReport {
         Optional<ServiceContractProto.ServiceContract> result = getServiceContract(request);
         if (!result.isPresent()) {
             // 降级，由兜底的 MetadataReport 进行处理
-            return another.map(proxyReport -> proxyReport.getMetadataReport().getAppMetadata(identifier, instanceMetadata)).orElse(MetadataInfo.EMPTY);
+            return another.map(proxyReport -> proxyReport.getMetadataReport().getAppMetadata(identifier, instanceMetadata)).orElse(null);
         }
 
         Map<String, MetadataInfo.ServiceInfo> serviceInfos = new HashMap<>();
@@ -397,7 +397,7 @@ public class PolarisMetadataReport extends AbstractMetadataReport {
     // -------- 仅用于 multi-metadata-report 情况下使用
     @Override
     public ConfigItem getConfigItem(String key, String group) {
-        return another.map(proxyReport -> proxyReport.getConfigItem(key, group)).orElse(null);
+        return another.map(proxyReport -> proxyReport.getConfigItem(key, group)).orElse(new ConfigItem());
     }
 
     @Override


### PR DESCRIPTION
接口的默认实现是返回`new ConfigItem()`，且调用方没有判空，因此需要修改。
<img width="600" alt="Clipboard_Screenshot_1744356193" src="https://github.com/user-attachments/assets/f7080bc2-e775-4aa2-a833-c98585df3d89" />
<img width="600" alt="Clipboard_Screenshot_1744356200" src="https://github.com/user-attachments/assets/421a1708-ac20-4640-a5ae-12e7bc104fa1" />

